### PR TITLE
Fix EasyEngine/easyengine#1363

### DIFF
--- a/src/Admin_Tools_Command.php
+++ b/src/Admin_Tools_Command.php
@@ -128,6 +128,8 @@ class Admin_Tools_Command extends EE_Command {
 			'ee_root_dir'   => EE_ROOT_DIR,
 			'db_path'       => DB,
 			'ee_admin_path' => '/var/www/htdocs/ee-admin',
+			'redis_host'    => $this->site_data->cache_host,
+			'db_host'       => $this->site_data->db_host,
 		];
 		$docker_compose_admin = EE\Utils\mustache_render( ADMIN_TEMPLATE_ROOT . '/docker-compose-admin.mustache', $docker_compose_data );
 		$this->fs->dumpFile( $this->site_data->site_fs_path . '/docker-compose-admin.yml', $docker_compose_admin );

--- a/templates/docker-compose-admin.mustache
+++ b/templates/docker-compose-admin.mustache
@@ -3,6 +3,9 @@ version: '3.5'
 services:
 
   php:
+    environment:
+      - REDIS_HOST={{redis_host}}
+      - DB_HOST={{db_host}}
     volumes:
       - "{{ee_root_dir}}/admin-tools:{{ee_admin_path}}:ro"
       - "{{db_path}}:{{db_path}}:ro"

--- a/templates/pma.config.mustache
+++ b/templates/pma.config.mustache
@@ -30,7 +30,7 @@ $i++;
 /* Authentication type */
 $cfg['Servers'][$i]['auth_type'] = 'cookie';
 /* Server parameters */
-$cfg['Servers'][$i]['host'] = 'global-db';
+$cfg['Servers'][$i]['host'] = getenv('DB_HOST');
 $cfg['Servers'][$i]['compress'] = false;
 $cfg['Servers'][$i]['AllowNoPassword'] = false;
 

--- a/templates/pra.config.mustache
+++ b/templates/pra.config.mustache
@@ -1,84 +1,50 @@
 <?php
 
-$config = array(
-  'servers' => array(
-    array(
-      'name'   => getenv('VIRTUAL_HOST'), // Optional name.
-      'host'   => 'global-redis',
-      'port'   => 6379,
-      'filter' => '*',
-      'scheme' => 'tcp', // Optional. Connection scheme. 'tcp' - for TCP connection, 'unix' - for connection by unix domain socket
-      'path'   => '' // Optional. Path to unix domain socket. Uses only if 'scheme' => 'unix'. Example: '/var/run/redis/redis.sock'
+include 'config.sample.inc.php';
 
-      // Optional Redis authentication.
-      //'auth' => 'redispasswordhere' // Warning: The password is sent in plain-text to the Redis server.
-    ),
+$admin_user = getenv('ADMIN_USER');
+$admin_pass = getenv('ADMIN_PASS');
 
-    /*array(
-      'host' => 'localhost',
-      'port' => 6380
-    ),*/
+if (!empty($admin_user)) {
+  $config['login'] = array(
+    $admin_user => array(
+'password' => $admin_pass,
+),
+);
+}
 
-    /*array(
-      'name'      => 'local db 2',
-      'host'      => 'localhost',
-      'port'      => 6379,
-      'db'        => 1,             // Optional database number, see http://redis.io/commands/select
-      'databases' => 1,             // Optional number of databases (prevents use of CONFIG command).
-      'filter'    => 'something:*', // Show only parts of database for speed or security reasons.
-      'seperator' => '/',           // Use a different seperator on this database (default uses config default).
-      'flush'     => false,         // Set to true to enable the flushdb button for this instance.
-      'charset'   => 'cp1251',      // Keys and values are stored in redis using this encoding (default utf-8).
-      'keys'      => false,         // Use the old KEYS command instead of SCAN to fetch all keys for this server (default uses config default).
-      'scansize'  => 1000           // How many entries to fetch using each SCAN command for this server (default uses config default).
-    ),*/
-  ),
+$config['servers'] = array();
 
+$prefix = 'REDIS_';
 
-  'seperator' => ':',
+$server_name = getenv($prefix . 'NAME');
+$server_host = getenv($prefix . 'HOST');
+$server_port = getenv($prefix . 'PORT');
+$server_auth = getenv($prefix . 'AUTH');
 
+if (empty($server_host)) {
+$server_host = "";
+}
 
-  // Uncomment to show less information and make phpRedisAdmin fire less commands to the Redis server. Recommended for a really busy Redis server.
-  //'faster' => true,
+if (empty($server_name)) {
+$server_name = $server_host;
+}
 
+if (empty($server_auth)) {
+$server_auth = "";
+}
 
-  // Uncomment to enable HTTP authentication
-  /*'login' => array(
-    // Username => Password
-    // Multiple combinations can be used
-    'admin' => array(
-      'password' => 'adminpassword',
-    ),
-    'guest' => array(
-      'password' => '',
-      'servers'  => array(1) // Optional list of servers this user can access.
-    )
-  ),*/
+if (empty($server_port)) {
+$server_port = 6379;
+}
 
-  // Use HTML form/cookie-based auth instead of HTTP Basic/Digest auth
-  'cookie_auth' => false,
-
-
-  /*'serialization' => array(
-    'foo*' => array( // Match like KEYS
-      // Function called when saving to redis.
-      'save' => function($data) { return json_encode(json_decode($data)); },
-      // Function called when loading from redis.
-      'load' => function($data) { return json_encode(json_decode($data), JSON_PRETTY_PRINT); },
-    ),
-  ),*/
-
-
-  // You can ignore settings below this point.
-
-  'maxkeylen'           => 100,
-  'count_elements_page' => 100,
-
-  // Use the old KEYS command instead of SCAN to fetch all keys.
-  'keys' => false,
-
-  // How many entries to fetch using each SCAN command.
-  'scansize' => 1000
+$config['servers'][] = array(
+'name'   => $server_name,
+'host'   => $server_host,
+'port'   => $server_port,
+'filter' => '*',
 );
 
-?>
+if (!empty($server_auth)) {
+$config['servers'][0]['auth'] = $server_auth;
+}


### PR DESCRIPTION
Closes EasyEngine/easyengine#1363
Closes https://github.com/EasyEngine/admin-tools-command/issues/20
1. Change template files to use environment variables
2. Add respective environment variables in docker-compose-admin.yml

Testing
1. Create two sites - one with `--with-local-redis` and one without
2. Check both sites have working PMA(`/ee-admin/pma`) and PRA(`/ee-admin/pra`)

Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>